### PR TITLE
Fix/prevent serializing symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msw-trpc",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Trpc API for Mock Service Worker (MSW).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/createTRPCMsw.ts
+++ b/src/createTRPCMsw.ts
@@ -82,7 +82,7 @@ const createTRPCMsw = <Router extends AnyRouter>(
   type ExtractKeys<T extends Router[any], K extends keyof T = keyof T> = T[K] extends
     | BuildProcedure<'query', any, any>
     | BuildProcedure<'mutation', any, any>
-    | Router[any]
+    | AnyRouter
     ? K
     : never
 
@@ -128,11 +128,11 @@ const createTRPCMsw = <Router extends AnyRouter>(
     ? Mutation<T, K>
     : T[K] extends BuildProcedure<'query', any, any>
     ? Query<T, K>
-    : T[K] extends Router[any]
+    : T[K] extends AnyRouter
     ? MswTrpc<T[K]>
     : never
 
-  type MswTrpc<T extends Router | Router[any]> = {
+  type MswTrpc<T extends Router | AnyRouter> = {
     [key in keyof T as ExtractKeys<T, key>]: ExtractProcedureHandler<T, key>
   }
 


### PR DESCRIPTION
Fixes a bug where a tRPC instance created with a transformer with symbols could not be exported

**Bug example**

```ts
const t = initTRPC.create({ transformer: superjson })

const appRouter = t.router({})

export const mswTrpc = mswTrpc<typeof appRouter>()
```
![image](https://user-images.githubusercontent.com/6407064/216785599-a0396610-eea1-49b1-8979-95a8586bf365.png)

This bug is related to: https://github.com/maloguertin/msw-trpc/issues/2 but I'm not sure it fixes it since I wasn't able to reproduce it yet.
