### PR TITLE
fix: :bug: ctx.data is now typed to responseTransformer

### DIFF
--- a/src/createTRPCMsw.ts
+++ b/src/createTRPCMsw.ts
@@ -4,6 +4,7 @@ import {
   MockedRequest,
   PathParams,
   ResponseResolver,
+  ResponseTransformer,
   rest,
   RestContext,
   RestHandler,
@@ -93,7 +94,9 @@ const createTRPCMsw = <Router extends AnyRouter>(
   }
 
   type ContextWithDataTransformer<T extends Router[any], K extends keyof T = keyof T> = RestContext & {
-    data: (data: T[K] extends BuildProcedure<any, any, infer P> ? P : never) => any
+    data: (
+      data: T[K] extends BuildProcedure<any, any, infer P> ? P : never
+    ) => ResponseTransformer<DefaultBodyType, any>
   }
 
   type SetQueryHandler<T extends Router[any], K extends keyof T> = (


### PR DESCRIPTION
Closes #6

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?
ctx.data now returns responseTransformer 
## ✅ Checklist

- [ ] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
