### PR TITLE
fix variable name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ export const trpcMsw = createTRPCMsw<AppRouter>() /* 👈 */
 
 ```typescript
 const server = setupServer(
-  mswTrpc.userById.query((req, res, ctx) => {
+  trpcMsw.userById.query((req, res, ctx) => {
     return res(ctx.status(200), ctx.data({ id: '1', name: 'Uncle bob' }))
   }),
-  mswTrpc.createUser.mutation(async (req, res, ctx) => {
+  trpcMsw.createUser.mutation(async (req, res, ctx) => {
     return res(ctx.status(200), ctx.data({ id: '2', name: await req.json() }))
   })
 )


### PR DESCRIPTION
Closes #

## 🎯 Changes

Just fixing a variable name in the README.
(mswTrpc => trpcMsw)

Only this section has the variable name mswTrpc, while the other sections have the variable name trpcMsw.

## ✅ Checklist

- [x] If necessary, I have added documentation related to the changes made.
- [ ] I have added or updated the tests related to the changes made.
