### PR TITLE
fix: ctx.data returns correct type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4,13 +4,14 @@ import {
   MockedRequest,
   PathParams,
   ResponseResolver,
+  ResponseTransformer,
   RestContext,
   RestHandler,
   RestRequest,
 } from 'msw'
 
 export type ContextWithDataTransformer<T> = RestContext & {
-  data: (data: T extends BuildProcedure<any, any, infer P> ? P : never) => any
+  data: (data: T extends BuildProcedure<any, any, infer P> ? P : never) => ResponseTransformer<DefaultBodyType, any>
 }
 
 export type ExtractKeys<T, K extends keyof T = keyof T> = T[K] extends

--- a/test/createTRPCMsw.test.ts
+++ b/test/createTRPCMsw.test.ts
@@ -7,8 +7,8 @@ import {
   RestHandler,
   MockedRequest,
   RestContext,
+  ResponseTransformer,
 } from 'msw'
-import superjson from 'superjson'
 import { mswTrpc, mswTrpcWithSuperJson, nestedMswTrpc, User } from './setup'
 
 describe('proxy returned by createMswTrpc', () => {
@@ -18,7 +18,7 @@ describe('proxy returned by createMswTrpc', () => {
         handler: ResponseResolver<
           RestRequest<never, PathParams<string>> & { getInput: () => string },
           RestContext & {
-            data: (data: User | undefined) => any
+            data: (data: User | undefined) => ResponseTransformer<DefaultBodyType, any>
           },
           DefaultBodyType
         >
@@ -32,7 +32,7 @@ describe('proxy returned by createMswTrpc', () => {
         handler: ResponseResolver<
           RestRequest<string, PathParams> & { getInput: () => string },
           RestContext & {
-            data: (data: User) => any
+            data: (data: User) => ResponseTransformer<DefaultBodyType, any>
           }
         >
       ) => RestHandler<MockedRequest<DefaultBodyType>>
@@ -46,7 +46,7 @@ describe('proxy returned by createMswTrpc', () => {
           handler: ResponseResolver<
             RestRequest<never, PathParams<string>> & { getInput: () => string },
             RestContext & {
-              data: (data: User | undefined) => any
+              data: (data: User | undefined) => ResponseTransformer<DefaultBodyType, any>
             },
             DefaultBodyType
           >
@@ -62,7 +62,7 @@ describe('proxy returned by createMswTrpc', () => {
           handler: ResponseResolver<
             RestRequest<string, PathParams> & { getInput: () => string },
             RestContext & {
-              data: (data: User) => ReturnType<superjson['serialize']>
+              data: (data: User) => ResponseTransformer<DefaultBodyType, any>
             }
           >
         ) => RestHandler<MockedRequest<DefaultBodyType>>
@@ -75,7 +75,7 @@ describe('proxy returned by createMswTrpc', () => {
           handler: ResponseResolver<
             RestRequest<never, PathParams<string>> & { getInput: () => string },
             RestContext & {
-              data: (data: User | undefined) => any
+              data: (data: User | undefined) => ResponseTransformer<DefaultBodyType, any>
             },
             DefaultBodyType
           >


### PR DESCRIPTION
## 🎯 Changes

ctx.data return type is now `ResponseTransformer<DefaultBodyType, any>` instead of any

## ✅ Checklist

- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
