### PR TITLE
fix: ctx.data arguments type with output parser

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { AnyRouter, BuildProcedure, ProcedureParams, inferRouterInputs } from '@trpc/server'
+import { AnyRouter, BuildProcedure, Procedure, ProcedureParams, ProcedureType, inferRouterInputs } from '@trpc/server'
 import {
   DefaultBodyType,
   MockedRequest,
@@ -11,7 +11,9 @@ import {
 } from 'msw'
 
 export type ContextWithDataTransformer<T> = RestContext & {
-  data: (data: T extends BuildProcedure<any, any, infer P> ? P : never) => ResponseTransformer<DefaultBodyType, any>
+  data: (
+    data: T extends Procedure<ProcedureType, infer ProcedureParams> ? ProcedureParams['_output_out'] : never
+  ) => ResponseTransformer<DefaultBodyType, any>
 }
 
 export type ExtractKeys<T, K extends keyof T = keyof T> = T[K] extends

--- a/test/createTRPCMsw.test.ts
+++ b/test/createTRPCMsw.test.ts
@@ -83,4 +83,34 @@ describe('proxy returned by createMswTrpc', () => {
       >()
     })
   })
+
+  describe('with output transformer', () => {
+    it('query context.data should consider output transformer', () => {
+      expectTypeOf(mswTrpc.userByName.query).toEqualTypeOf<
+        (
+          handler: ResponseResolver<
+            RestRequest<never, PathParams<string>> & { getInput: () => string },
+            RestContext & {
+              data: (data: User | undefined) => ResponseTransformer<DefaultBodyType, any>
+            },
+            DefaultBodyType
+          >
+        ) => RestHandler<MockedRequest<DefaultBodyType>>
+      >()
+    })
+
+    it('mutation context.data should consider output transformer', () => {
+      expectTypeOf(mswTrpc.updateUser.mutation).toEqualTypeOf<
+        (
+          handler: ResponseResolver<
+            RestRequest<User, PathParams> & { getInput: () => Promise<User> },
+            RestContext & {
+              data: (data: User) => ResponseTransformer<DefaultBodyType, any>
+            },
+            DefaultBodyType
+          >
+        ) => RestHandler<MockedRequest<DefaultBodyType>>
+      >()
+    })
+  })
 })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -48,6 +48,31 @@ const appRouter = t.router({
 
       return { ...user, posts: ['1'] }
     }),
+  userByName: t.procedure
+    .input((val: unknown) => {
+      if (typeof val === 'string') return val
+
+      throw new Error(`Invalid input: ${typeof val}`)
+    })
+    .output((val: unknown) => {
+      if (typeof val === 'undefined') {
+        return val
+      }
+      if (typeof val !== 'object' || val === null) {
+        throw new Error(`Invalid output: ${typeof val}`)
+      }
+      if (!('id' in val) || typeof val.id !== 'string' || !('name' in val) || typeof val.name !== 'string') {
+        throw new Error(`Invalid output: ${typeof val}`)
+      }
+      return val as User
+    })
+    .query(req => {
+      const { input } = req
+
+      const user = userList.find(u => u.name === input)
+
+      return user
+    }),
   createUser: t.procedure
     .input((val: unknown) => {
       if (typeof val === 'string') return val
@@ -61,6 +86,33 @@ const appRouter = t.router({
         id: '2',
         name: input,
       } as User
+    }),
+  updateUser: t.procedure
+    .input((val: unknown) => {
+      if (typeof val !== 'object' || val === null) {
+        throw new Error(`Invalid input: ${typeof val}`)
+      }
+      if (!('id' in val) || !('name' in val)) {
+        throw new Error(`Invalid input: ${typeof val}`)
+      }
+      if (typeof val.id !== 'string' || typeof val.name !== 'string') {
+        throw new Error(`Invalid input: ${typeof val}`)
+      }
+      return val as User
+    })
+    .output((val: unknown) => {
+      if (typeof val !== 'object' || val === null) {
+        throw new Error(`Invalid output: ${typeof val}`)
+      }
+      if (!('id' in val) || typeof val.id !== 'string' || !('name' in val) || typeof val.name !== 'string') {
+        throw new Error(`Invalid output: ${typeof val}`)
+      }
+      return val as User
+    })
+    .mutation(req => {
+      const { input } = req
+
+      return input
     }),
 })
 


### PR DESCRIPTION
Close #22 

## 🎯 Changes

Currently, when using the output parser, the argument type of `ctx.data` is `undefined`. So, I modified it to take output parser into account.

Please review when you have time.

## ✅ Checklist

- [x] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
