### PR TITLE
fix: Throwing errors with superjson (msw 2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "2.0.0-beta.0",
       "license": "MIT",
       "devDependencies": {
-        "@trpc/client": "^10.9.0",
-        "@trpc/react-query": "^10.9.0",
-        "@trpc/server": "^10.9.0",
+        "@trpc/client": "^10.44.1",
+        "@trpc/react-query": "^10.44.1",
+        "@trpc/server": "^10.44.1",
         "@types/jest": "^29.2.6",
         "expect-type": "^0.15.0",
         "jest": "^29.3.1",
@@ -23,7 +23,7 @@
         "ts-jest": "^29.0.5",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5",
-        "zod": "^3.20.2"
+        "zod": "^3.22.4"
       },
       "peerDependencies": {
         "@trpc/server": ">=10.9.0",
@@ -1168,41 +1168,44 @@
       }
     },
     "node_modules/@trpc/client": {
-      "version": "10.40.0",
-      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-10.40.0.tgz",
-      "integrity": "sha512-bT6BcdWjj0KzGQiimE6rB2tIaRYX0Ear4Gthb5szN/c01wrP0yC1Fbz2uCcm/QTVAwu4Lve5M+YjPoEaTHG6lg==",
+      "version": "10.44.1",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-10.44.1.tgz",
+      "integrity": "sha512-vTWsykNcgz1LnwePVl2fKZnhvzP9N3GaaLYPkfGINo314ZOS0OBqe9x0ytB2LLUnRVTAAZ2WoONzARd8nHiqrA==",
       "dev": true,
       "funding": [
         "https://trpc.io/sponsor"
       ],
       "peerDependencies": {
-        "@trpc/server": "10.40.0"
+        "@trpc/server": "10.44.1"
       }
     },
     "node_modules/@trpc/react-query": {
-      "version": "10.40.0",
-      "resolved": "https://registry.npmjs.org/@trpc/react-query/-/react-query-10.40.0.tgz",
-      "integrity": "sha512-DpJrV3lmYNo9xtPtcg49lfh9CUFap3ZivjhlSmfe4QPf7H6xBjAE+ml4OdJ0RmKvSTFvbLSOiNdB1k5O8zIdzQ==",
+      "version": "10.44.1",
+      "resolved": "https://registry.npmjs.org/@trpc/react-query/-/react-query-10.44.1.tgz",
+      "integrity": "sha512-Sgi/v0YtdunOXjBRi7om9gILGkOCFYXPzn5KqLuEHiZw5dr5w4qGHFwCeMAvndZxmwfblJrl1tk2AznmsVu8MA==",
       "dev": true,
       "funding": [
         "https://trpc.io/sponsor"
       ],
       "peerDependencies": {
         "@tanstack/react-query": "^4.18.0",
-        "@trpc/client": "10.40.0",
-        "@trpc/server": "10.40.0",
+        "@trpc/client": "10.44.1",
+        "@trpc/server": "10.44.1",
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@trpc/server": {
-      "version": "10.40.0",
-      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.40.0.tgz",
-      "integrity": "sha512-49SUOMWzSZtu5+OdrADmJD+u+sjSE0qj1cWgYk2FY4jLkPJunLuNRuhzM7aOeBhiUjyfhg2YTfur8FN1WBmvEw==",
+      "version": "10.44.1",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.44.1.tgz",
+      "integrity": "sha512-mF7B+K6LjuboX8I1RZgKE5GA/fJhsJ8tKGK2UBt3Bwik7hepEPb4NJgNr7vO6BK5IYwPdBLRLTctRw6XZx0sRg==",
       "dev": true,
       "funding": [
         "https://trpc.io/sponsor"
-      ]
+      ],
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/maloguertin/msw-trpc#readme",
   "devDependencies": {
-    "@trpc/client": "^10.9.0",
-    "@trpc/react-query": "^10.9.0",
-    "@trpc/server": "^10.9.0",
+    "@trpc/client": "^10.44.1",
+    "@trpc/react-query": "^10.44.1",
+    "@trpc/server": "^10.44.1",
     "@types/jest": "^29.2.6",
     "expect-type": "^0.15.0",
     "jest": "^29.3.1",
@@ -40,7 +40,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5",
-    "zod": "^3.20.2"
+    "zod": "^3.22.4"
   },
   "peerDependencies": {
     "@trpc/server": ">=10.9.0",

--- a/src/createTRPCMsw.ts
+++ b/src/createTRPCMsw.ts
@@ -16,7 +16,7 @@ const getQueryInput = (req: Request, transformer: CombinedDataTransformer) => {
 const getMutationInput = async (req: Request, transformer: CombinedDataTransformer) => {
   const body = await req.json()
 
-  return transformer.output.deserialize(body)
+  return transformer.input.deserialize(body)
 }
 
 const getRegexpAsString = (baseUrl: string | RegExp) => {
@@ -53,7 +53,7 @@ const createUntypedTRPCMsw = (
               async (params): Promise<any> => {
                 try {
                   const body = await handler(await getInput(params.request, transformer))
-                  return HttpResponse.json({ result: { data: transformer.input.serialize(body) } })
+                  return HttpResponse.json({ result: { data: transformer.output.serialize(body) } })
                 } catch (e) {
                   if (e instanceof TRPCError) {
                     const status = getHTTPStatusCodeFromError(e)

--- a/src/createTRPCMsw.ts
+++ b/src/createTRPCMsw.ts
@@ -57,16 +57,13 @@ const createUntypedTRPCMsw = (
                 } catch (e) {
                   if (e instanceof TRPCError) {
                     const status = getHTTPStatusCodeFromError(e)
-                    return HttpResponse.json(
-                      {
-                        error: {
-                          message: e.message,
-                          code: TRPC_ERROR_CODES_BY_KEY[e.code],
-                          data: { code: e.code, httpStatus: status },
-                        },
-                      },
-                      { status }
-                    )
+                    const path = pathParts.slice(1).join('.')
+                    const error = {
+                      message: e.message,
+                      code: TRPC_ERROR_CODES_BY_KEY[e.code],
+                      data: { code: e.code, httpStatus: status, path },
+                    }
+                    return HttpResponse.json({ error: transformer.output.serialize(error) }, { status })
                   } else {
                     throw e
                   }


### PR DESCRIPTION

Closes #33
Closes #35 
Closes #13

## 🎯 Changes

Fix: Error object should be serialized by superjson on the server
Fix: `error.data.path` should be populated

I had to manually match the error object because `toThrow` only checks the error type and message, not its content

## ✅ Checklist

- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
