### PR TITLE
fix: Allow mocking procedures with no return value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,8 +18,8 @@ export type ExtractInput<T extends ProcedureParams> = T extends ProcedureParams<
 export type ExtractOutput<T> = T extends Procedure<ProcedureType, infer ProcedureParams>
   ? ProcedureParams['_output_out'] extends DefaultBodyType
     ? ProcedureParams['_output_out']
-    : never
-  : never
+    : void
+  : void
 
 export type WithInput<T, K extends keyof T = keyof T> = T[K] extends BuildProcedure<any, any, any>
   ? T extends AnyRouter

--- a/test/createTRPCMsw.test.ts
+++ b/test/createTRPCMsw.test.ts
@@ -16,6 +16,15 @@ describe('proxy returned by createMswTrpc', () => {
     >()
   })
 
+  it('should interpret procedure without return as void', () => {
+    mswTrpc.noReturn.mutation(input => {
+      return
+    })
+    expectTypeOf(mswTrpc.noReturn.mutation).toEqualTypeOf<
+      (handler: (input: void) => PromiseOrValue<void>) => RequestHandler
+    >
+  })
+
   describe('with merged routers', () => {
     it('should expose property query on properties that match TRPC query procedures', () => {
       expectTypeOf(nestedMswTrpc.users.userById.query).toEqualTypeOf<

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -112,6 +112,7 @@ const appRouter = t.router({
 
       return input
     }),
+  noReturn: t.procedure.mutation(() => {}),
 })
 
 const appRouterWithSuperJson = tWithSuperJson.router({


### PR DESCRIPTION


## 🎯 Changes

The current types do not allow mocking a procedure that returns void, as it sets the expected return type to `never`

![image](https://github.com/maloguertin/msw-trpc/assets/17657014/ee508537-d534-4d1a-aaab-9bc3bf8050fe)


## ✅ Checklist

- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.
