### PR TITLE
Add websocket support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*.ts]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.tsx]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/packages/msw-trpc/src/create.ts
+++ b/packages/msw-trpc/src/create.ts
@@ -19,6 +19,12 @@ export const createTRPCMsw = <Router extends AnyTRPCRouter>(config: TRPCMswConfi
 
               return result
             }
+          } else if (lastKey === 'subscription') {
+            return (handler?: Function) => {
+              const result = trpc[lastKey](procedurePath, handler, { links, transformer })
+
+              return result
+            }
           }
 
           return createUntypedTRPCMsw([...pathParts, lastKey as string])
@@ -29,3 +35,4 @@ export const createTRPCMsw = <Router extends AnyTRPCRouter>(config: TRPCMswConfi
 
   return createUntypedTRPCMsw() as MswTrpc<Router>
 }
+

--- a/packages/msw-trpc/src/create.ts
+++ b/packages/msw-trpc/src/create.ts
@@ -35,4 +35,3 @@ export const createTRPCMsw = <Router extends AnyTRPCRouter>(config: TRPCMswConfi
 
   return createUntypedTRPCMsw() as MswTrpc<Router>
 }
-

--- a/packages/msw-trpc/src/handler.ts
+++ b/packages/msw-trpc/src/handler.ts
@@ -1,11 +1,16 @@
-import { http, HttpResponse } from 'msw'
+import { http, HttpResponse, WebSocketLink, ws } from 'msw'
 import { Link } from './links.js'
 import { TRPCCombinedDataTransformer, TRPCError } from '@trpc/server'
 import {
   TRPC_ERROR_CODES_BY_KEY,
   TRPC_ERROR_CODE_KEY,
+  Unpromise,
   defaultTransformer,
   getHTTPStatusCodeFromError,
+  getTRPCErrorFromUnknown,
+  isTrackedEnvelope,
+  iteratorResource,
+  run,
 } from '@trpc/server/unstable-core-do-not-import'
 
 import { TRPCMswConfig } from './types.js'
@@ -26,8 +31,27 @@ const getMutationInput = async (req: Request, transformer: TRPCCombinedDataTrans
   return transformer.input.deserialize(body)
 }
 
+const getSerializedTrpcError = (e: unknown, path: string, transformer = defaultTransformer) => {
+  const error = getTRPCErrorFromUnknown(e)
+
+  const jsonError = {
+    message: error.message,
+    code: TRPC_ERROR_CODES_BY_KEY[error.code],
+    data: {
+      code: error.code,
+      httpStatus: getHTTPStatusCodeFromError(error),
+      path,
+      stack: error.stack,
+    },
+  }
+
+  return transformer.output.serialize(jsonError)
+}
+
+const wsLinks = new Map<string, WebSocketLink>()
+
 const createTrpcHandler = (
-  procedureType: 'query' | 'mutation',
+  procedureType: 'query' | 'mutation' | 'subscription',
   path: string,
   handler: Function | undefined,
   {
@@ -83,7 +107,196 @@ const createTrpcHandler = (
           return HttpResponse.json({ error: transformer.output.serialize(jsonError) }, { status })
         }
       })
+    } else if (procedureType === 'subscription') {
+      throw new Error('Subscriptions require a WebSocket link (wsLink)')
     }
+    throw new Error('Unknown procedure type')
+  } else if (handlerType === 'ws') {
+    const wsLink = wsLinks.get(url) ?? wsLinks.set(url, ws.link(url)).get(url)!
+    const clients = new Map<string, Map<number | string, AbortController>>()
+
+    return wsLink.addEventListener('connection', ({ client }) => {
+      if (!clients.has(client.id)) {
+        clients.set(client.id, new Map())
+      }
+
+      const clientSubscriptions = clients.get(client.id)!
+
+      client.addEventListener('message', async (event) => {
+        const message = JSON.parse(event.data.toString()) as {
+          id: number | string
+          jsonrpc?: '2.0'
+          method: 'query' | 'mutation' | 'subscription'
+          params: {
+            path: string
+            input?: unknown
+          }
+        }
+
+        try {
+          if (message.params.path === path) {
+            const input = transformer.input.deserialize(message.params.input)
+
+            if (message.method === 'subscription') {
+              if (handler === undefined) {
+                handler = async function* () {}
+              }
+
+              // WebSocket.OPEN = 1
+              if (client.socket.readyState !== 1) {
+                return;
+              }
+
+              if (clientSubscriptions.has(message.id)) {
+                // duplicate request ids for client
+
+                throw new TRPCError({
+                  message: `Duplicate id ${message.id}`,
+                  code: 'BAD_REQUEST',
+                });
+              }
+
+              const abortController = new AbortController();
+
+              run(async () => {
+                const abortPromise = new Promise<'abort'>((resolve) => {
+                  abortController.signal.onabort = () => resolve('abort');
+                });
+
+                const opts = {
+                  input,
+                  signal: abortController.signal,
+                }
+
+                await using iterator = iteratorResource(handler!(opts) as AsyncIterable<unknown, void, unknown>);
+
+                let next:
+                  | null
+                  | TRPCError
+                  | Awaited<
+                      typeof abortPromise | ReturnType<(typeof iterator)['next']>
+                    >;
+
+                while (true) {
+                  next = await Unpromise.race([
+                    iterator.next().catch(getTRPCErrorFromUnknown),
+                    abortPromise,
+                  ]);
+
+                  if (next === 'abort') {
+                    await iterator.return?.();
+                    break;
+                  }
+                  if (next instanceof Error) {
+                    client.send(
+                      JSON.stringify({
+                        id: message.id,
+                        jsonrpc: message.jsonrpc,
+                        error: getSerializedTrpcError(next, path, transformer),
+                      })
+                    )
+                    continue;
+                  }
+                  if (next.done) {
+                    break;
+                  }
+
+                  if (isTrackedEnvelope(next.value)) {
+                    const [id, data] = next.value;
+                    client.send(
+                      JSON.stringify({
+                        id,
+                        jsonrpc: message.jsonrpc,
+                        result: {
+                          type: 'data',
+                          data: {
+                            id,
+                            data: transformer.output.serialize(data),
+                          },
+                        },
+                      })
+                    )
+                  } else {
+                    client.send(
+                      JSON.stringify({
+                        id: message.id,
+                        jsonrpc: message.jsonrpc,
+                        result: {
+                          type: 'data',
+                          data: transformer.output.serialize(next.value),
+                        },
+                      })
+                    )
+                  }
+                }
+
+                client.send(
+                  JSON.stringify({
+                    id: message.id,
+                    jsonrpc: message.jsonrpc,
+                    result: {
+                      type: 'stopped',
+                    },
+                  })
+                )
+                clientSubscriptions.delete(message.id)
+              }).catch((cause) => {
+                const error = getTRPCErrorFromUnknown(cause);
+                client.send(
+                  JSON.stringify({
+                    id: message.id,
+                    jsonrpc: message.jsonrpc,
+                    error: getSerializedTrpcError(error, path),
+                  })
+                )
+                abortController.abort();
+              });
+              clientSubscriptions.set(message.id, abortController);
+
+              client.send(
+                JSON.stringify({
+                  id: message.id,
+                  jsonrpc: message.jsonrpc,
+                  result: {
+                    type: 'started',
+                  },
+                })
+              )
+            } else {
+              const result = await handler!({ input }) // TS doesn't seem to understand that handler is defined here, despite the check above
+
+              client.send(
+                JSON.stringify({
+                  id: message.id,
+                  jsonrpc: message.jsonrpc,
+                  result: {
+                    type: 'data',
+                    data: transformer.output.serialize(result),
+                  },
+                })
+              )
+            }
+          }
+        } catch (e) {
+          client.send(
+            JSON.stringify({
+              id: message.id,
+              jsonrpc: message.jsonrpc,
+              error: getSerializedTrpcError(e, path),
+            })
+          )
+        }
+      })
+
+      client.addEventListener(
+        'close',
+        () => {
+          clientSubscriptions.forEach((abortController) => abortController.abort());
+          clients.delete(client.id);
+        },
+        { once: true }
+      )
+    });
   }
 
   throw new Error('Unknown handler type')
@@ -93,4 +306,6 @@ export const trpc = {
   query: (path: string, handler: Function, opts: TRPCMswConfig) => createTrpcHandler('query', path, handler, opts),
   mutation: (path: string, handler: Function, opts: TRPCMswConfig) =>
     createTrpcHandler('mutation', path, handler, opts),
+  subscription: (path: string, handler: Function | undefined, opts: TRPCMswConfig) =>
+    createTrpcHandler('subscription', path, handler, opts),
 }

--- a/packages/msw-trpc/src/links.ts
+++ b/packages/msw-trpc/src/links.ts
@@ -1,6 +1,6 @@
 import { Operation } from '@trpc/client'
 
-type LinkType = 'http'
+type LinkType = 'http' | 'ws'
 
 export type Link = (op?: Pick<Operation, 'type' | 'path'>) => { type: LinkType; url: string; methodOverride?: 'POST' }
 
@@ -22,4 +22,16 @@ export const splitLink = (opts: {
     const link = opts.condition(op) ? opts.true : opts.false
     return link()
   }) as Link
+}
+
+export const createWSClient = <T extends { url: string }>({ url }: T) => ({
+  url,
+})
+
+export const wsLink = <T extends { client: { url: string } }>(arg: T): Link => {
+  return () =>
+    ({
+      type: 'ws',
+      url: arg.client.url,
+    }) as const
 }

--- a/packages/msw-trpc/src/types.ts
+++ b/packages/msw-trpc/src/types.ts
@@ -43,16 +43,20 @@ export type ProcedureHandlerRecord<TRouter extends AnyTRPCRouter, TRecord extend
             }
           : $Value['_def']['type'] extends 'subscription'
             ? {
-              subscription: (
-                handler?: ({
-                  input,
-                  signal,
-                }: {
-                  input: inferProcedureInput<$Value>,
-                  signal: AbortSignal | undefined,
-                }) => AsyncIterable<inferAsyncIterableYield<inferTransformedProcedureOutputOrVoid<TRouter, $Value>>, void, unknown>
-              ) => WebSocketHandler
-            }
+                subscription: (
+                  handler?: ({
+                    input,
+                    signal,
+                  }: {
+                    input: inferProcedureInput<$Value>
+                    signal: AbortSignal | undefined
+                  }) => AsyncIterable<
+                    inferAsyncIterableYield<inferTransformedProcedureOutputOrVoid<TRouter, $Value>>,
+                    void,
+                    unknown
+                  >
+                ) => WebSocketHandler
+              }
             : never
         : never
     : never

--- a/packages/test-node/src/lazy-websocket.ts
+++ b/packages/test-node/src/lazy-websocket.ts
@@ -1,0 +1,14 @@
+import { WebSocket } from 'undici'
+
+Reflect.set(globalThis, 'WebSocket', WebSocket)
+
+export class LazyWebSocket {
+  static CLOSED = globalThis.WebSocket.CLOSED
+  static CLOSING = globalThis.WebSocket.CLOSING
+  static CONNECTING = globalThis.WebSocket.CONNECTING
+  static OPEN = globalThis.WebSocket.OPEN
+
+  constructor(...args: ConstructorParameters<typeof globalThis.WebSocket>) {
+    return new globalThis.WebSocket(...args)
+  }
+}

--- a/packages/test-node/src/links/index.test.ts
+++ b/packages/test-node/src/links/index.test.ts
@@ -1,4 +1,3 @@
-import EventEmitter, { on } from 'events'
 import { HttpHandler, WebSocketHandler } from 'msw'
 import { describe, test, expect } from 'vitest'
 

--- a/packages/test-node/src/links/index.test.ts
+++ b/packages/test-node/src/links/index.test.ts
@@ -1,4 +1,4 @@
-import EventEmitter, { on } from 'events';
+import EventEmitter, { on } from 'events'
 import { HttpHandler, WebSocketHandler } from 'msw'
 import { describe, test, expect } from 'vitest'
 
@@ -42,15 +42,15 @@ describe('building handlers based on trpc links', () => {
         client: createWSClient({
           url: 'ws://localhost:3001/trpc',
         }),
-      })
+      }),
     ]
 
     test('should intercept ws handler', async () => {
       const mswTrpc = createTRPCMsw<AppRouter>({ links: mswLinks })
 
       const myAsyncGenerator = async function* (opts: { input: string; signal?: AbortSignal }) {
-          yield { id: opts.input, name: 'Toto' }
-        };
+        yield { id: opts.input, name: 'Toto' }
+      }
 
       typeof myAsyncGenerator
 
@@ -66,7 +66,9 @@ describe('building handlers based on trpc links', () => {
     test('should intercept ws handler with nested routers', async () => {
       const nestedMswTrpc = createTRPCMsw<NestedAppRouter>({ links: mswLinks })
 
-      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(WebSocketHandler)
+      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(
+        WebSocketHandler
+      )
       expect(nestedMswTrpc.deeply.nested.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(
         WebSocketHandler
       )
@@ -111,9 +113,7 @@ describe('with split link', () => {
     test('should use correct handler with nested routers', async () => {
       const nestedMswTrpc = createTRPCMsw<NestedAppRouter>({ links: mswLinks })
 
-      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(
-        HttpHandler
-      )
+      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(HttpHandler)
       expect(nestedMswTrpc.deeply.nested.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(
         HttpHandler
       )
@@ -153,7 +153,7 @@ describe('with split link', () => {
       expect(mswTrpc.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(WebSocketHandler)
       expect(
         mswTrpc.getUserUpdates.subscription(async function* (opts) {
-          yield { id: opts.input, name: 'Toto' };
+          yield { id: opts.input, name: 'Toto' }
         })
       ).toBeInstanceOf(WebSocketHandler)
     })
@@ -181,9 +181,7 @@ describe('with split link', () => {
 
       const nestedMswTrpc = createTRPCMsw<NestedAppRouter>({ links: mswLinks })
 
-      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(
-        HttpHandler
-      )
+      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(HttpHandler)
       expect(nestedMswTrpc.deeply.nested.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(
         WebSocketHandler
       )
@@ -195,4 +193,3 @@ describe('with split link', () => {
     })
   })
 })
-

--- a/packages/test-node/src/links/index.test.ts
+++ b/packages/test-node/src/links/index.test.ts
@@ -1,9 +1,10 @@
-import { HttpHandler } from 'msw'
+import EventEmitter, { on } from 'events';
+import { HttpHandler, WebSocketHandler } from 'msw'
 import { describe, test, expect } from 'vitest'
 
 import { AppRouter, NestedAppRouter } from '../routers.js'
 import { createTRPCMsw } from '../../../msw-trpc/src/index.js'
-import { httpLink } from '../../../msw-trpc/src/links.js'
+import { createWSClient, httpLink, splitLink, wsLink } from '../../../msw-trpc/src/links.js'
 
 describe('building handlers based on trpc links', () => {
   describe('with http link', () => {
@@ -34,4 +35,164 @@ describe('building handlers based on trpc links', () => {
       )
     })
   })
+
+  describe('with ws link', () => {
+    const mswLinks = [
+      wsLink({
+        client: createWSClient({
+          url: 'ws://localhost:3001/trpc',
+        }),
+      })
+    ]
+
+    test('should intercept ws handler', async () => {
+      const mswTrpc = createTRPCMsw<AppRouter>({ links: mswLinks })
+
+      const myAsyncGenerator = async function* (opts: { input: string; signal?: AbortSignal }) {
+          yield { id: opts.input, name: 'Toto' }
+        };
+
+      typeof myAsyncGenerator
+
+      expect(mswTrpc.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(WebSocketHandler)
+      expect(mswTrpc.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(WebSocketHandler)
+      expect(
+        mswTrpc.getUserUpdates.subscription(async function* (opts) {
+          yield { id: opts.input, name: 'Toto' }
+        })
+      ).toBeInstanceOf(WebSocketHandler)
+    })
+
+    test('should intercept ws handler with nested routers', async () => {
+      const nestedMswTrpc = createTRPCMsw<NestedAppRouter>({ links: mswLinks })
+
+      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(WebSocketHandler)
+      expect(nestedMswTrpc.deeply.nested.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(
+        WebSocketHandler
+      )
+    })
+  })
 })
+
+describe('with split link', () => {
+  describe('with a condition on type', () => {
+    const mswLinks = [
+      splitLink({
+        condition: (op) => op.type === 'subscription',
+        true: wsLink({
+          client: createWSClient({
+            url: 'ws://localhost:3001',
+          }),
+          onOpen() {},
+        }),
+        false: httpLink({
+          url: 'http://localhost:3000/trpc',
+          headers() {
+            return {
+              'content-type': 'application/json',
+            }
+          },
+        }),
+      }),
+    ]
+
+    test('should use correct handler', async () => {
+      const mswTrpc = createTRPCMsw<AppRouter>({ links: mswLinks })
+
+      expect(mswTrpc.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(HttpHandler)
+      expect(mswTrpc.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(HttpHandler)
+      expect(
+        mswTrpc.getUserUpdates.subscription(async function* (opts) {
+          yield { id: opts.input, name: 'Toto' }
+        })
+      ).toBeInstanceOf(WebSocketHandler)
+    })
+
+    test('should use correct handler with nested routers', async () => {
+      const nestedMswTrpc = createTRPCMsw<NestedAppRouter>({ links: mswLinks })
+
+      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(
+        HttpHandler
+      )
+      expect(nestedMswTrpc.deeply.nested.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(
+        HttpHandler
+      )
+      expect(
+        nestedMswTrpc.deeply.nested.getUserUpdates.subscription(async function* (opts) {
+          yield { id: opts.input, name: 'Toto' }
+        })
+      ).toBeInstanceOf(WebSocketHandler)
+    })
+  })
+
+  describe('with a condition on path', () => {
+    test('should use correct handler', async () => {
+      const mswLinks = [
+        splitLink({
+          condition: (op) => op.type === 'subscription' || op.path === 'createUser',
+          true: wsLink({
+            client: createWSClient({
+              url: 'ws://localhost:3001',
+            }),
+            onOpen() {},
+          }),
+          false: httpLink({
+            url: 'http://localhost:3000/trpc',
+            headers() {
+              return {
+                'content-type': 'application/json',
+              }
+            },
+          }),
+        }),
+      ]
+
+      const mswTrpc = createTRPCMsw<AppRouter>({ links: mswLinks })
+
+      expect(mswTrpc.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(HttpHandler)
+      expect(mswTrpc.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(WebSocketHandler)
+      expect(
+        mswTrpc.getUserUpdates.subscription(async function* (opts) {
+          yield { id: opts.input, name: 'Toto' };
+        })
+      ).toBeInstanceOf(WebSocketHandler)
+    })
+
+    test('should use correct handler with nested routers', async () => {
+      const mswLinks = [
+        splitLink({
+          condition: (op) => op.type === 'subscription' || op.path === 'deeply.nested.createUser',
+          true: wsLink({
+            client: createWSClient({
+              url: 'ws://localhost:3001',
+            }),
+            onOpen() {},
+          }),
+          false: httpLink({
+            url: 'http://localhost:3000/trpc',
+            headers() {
+              return {
+                'content-type': 'application/json',
+              }
+            },
+          }),
+        }),
+      ]
+
+      const nestedMswTrpc = createTRPCMsw<NestedAppRouter>({ links: mswLinks })
+
+      expect(nestedMswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' }))).toBeInstanceOf(
+        HttpHandler
+      )
+      expect(nestedMswTrpc.deeply.nested.createUser.mutation(({ input }) => ({ id: '2', name: input }))).toBeInstanceOf(
+        WebSocketHandler
+      )
+      expect(
+        nestedMswTrpc.deeply.nested.getUserUpdates.subscription(async function* (opts) {
+          yield { id: opts.input, name: 'Toto' }
+        })
+      ).toBeInstanceOf(WebSocketHandler)
+    })
+  })
+})
+

--- a/packages/test-node/src/routers.ts
+++ b/packages/test-node/src/routers.ts
@@ -45,6 +45,15 @@ const appRouter = t.router({
   deleteAllUsers: t.procedure.mutation(() => {
     return true
   }),
+  getUserUpdates: t.procedure
+    .input((val: unknown) => {
+      if (typeof val === 'string') return val
+
+      throw new Error(`Invalid input: ${typeof val}`)
+    })
+    .subscription(async function* (opts) {
+      yield { id: opts.input, name: 'Marie' } as User
+    }),
 })
 
 const nestedRouter = t.router({ deeply: { nested: appRouter } })

--- a/packages/test-node/src/websocket-split/index.test.ts
+++ b/packages/test-node/src/websocket-split/index.test.ts
@@ -53,8 +53,8 @@ describe('with split link', () => {
 
     test('handles subscriptions properly', async () => {
       const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
-        const id = opts.input;
-        yield await new Promise(resolve => setTimeout(() => resolve({id, name: 'Toto'}), 1000));
+        const id = opts.input
+        yield await new Promise((resolve) => setTimeout(() => resolve({ id, name: 'Toto' }), 1000))
       })
 
       server.use(subscription)
@@ -72,10 +72,10 @@ describe('with split link', () => {
 
     test('can receive multiple subscription updates', async () => {
       const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
-        const id = opts.input;
+        const id = opts.input
         const names = ['Toto', 'Tutu', 'Titi']
         for (let i = 0; i < names.length; i++) {
-          yield await new Promise(resolve => setTimeout(() => resolve({id, name: names[i]!}), i * 50));
+          yield await new Promise((resolve) => setTimeout(() => resolve({ id, name: names[i]! }), i * 50))
         }
       })
 
@@ -104,7 +104,7 @@ describe('with split link', () => {
 
     test('can trigger subscription data', async () => {
       const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
-        yield await new Promise(resolve => setTimeout(() => resolve({id: opts.input, name: 'Didier'}), 1000));
+        yield await new Promise((resolve) => setTimeout(() => resolve({ id: opts.input, name: 'Didier' }), 1000))
       })
 
       server.use(subscription)
@@ -151,8 +151,8 @@ describe('with split link', () => {
 
     test('handles subscriptions properly', async () => {
       const subscription = mswTrpc.deeply.nested.getUserUpdates.subscription(async function* (opts) {
-        const id = opts.input;
-        yield await new Promise(resolve => setTimeout(() => resolve({id, name: 'Tutu'}), 1000));
+        const id = opts.input
+        yield await new Promise((resolve) => setTimeout(() => resolve({ id, name: 'Tutu' }), 1000))
       })
 
       server.use(subscription)

--- a/packages/test-node/src/websocket-split/index.test.ts
+++ b/packages/test-node/src/websocket-split/index.test.ts
@@ -1,0 +1,171 @@
+import { createTRPCClient } from '@trpc/client'
+
+import { setupServer } from 'msw/node'
+import { describe, test, beforeAll, afterAll, expect, afterEach } from 'vitest'
+
+import { createLinks } from './links.js'
+import { AppRouter, NestedAppRouter, User } from '../routers.js'
+import { createTRPCMsw } from '../../../msw-trpc/src/index.js'
+import { createWSClient, httpLink, splitLink, wsLink } from '../../../msw-trpc/src/links.js'
+
+const mswLinks = [
+  splitLink({
+    condition: (op) => op.type === 'subscription',
+    true: wsLink({
+      client: createWSClient({
+        url: 'ws://localhost:3001',
+      }),
+    }),
+    false: httpLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  }),
+]
+
+describe('with split link', () => {
+  const server = setupServer()
+
+  beforeAll(() => server.listen())
+  afterAll(() => server.close())
+
+  describe('simple router', () => {
+    const mswTrpc = createTRPCMsw<AppRouter>({ links: mswLinks })
+
+    afterEach(() => server.resetHandlers())
+
+    test('handles queries properly', async () => {
+      server.use(mswTrpc.userById.query(() => ({ id: '1', name: 'Malo' })))
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+      const user = await trpc.userById.query('1')
+
+      expect(user).toEqual({ id: '1', name: 'Malo' })
+    })
+
+    test('handles mutations properly', async () => {
+      server.use(mswTrpc.createUser.mutation(({ input }) => ({ id: '2', name: input })))
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+      const user = await trpc.createUser.mutate('Robert')
+
+      expect(user).toEqual({ id: '2', name: 'Robert' })
+    })
+
+    test('handles subscriptions properly', async () => {
+      const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
+        const id = opts.input;
+        yield await new Promise(resolve => setTimeout(() => resolve({id, name: 'Toto'}), 1000));
+      })
+
+      server.use(subscription)
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+
+      const promise = new Promise<User>((resolve) => {
+        trpc.getUserUpdates.subscribe('3', {
+          onData: resolve,
+        })
+      })
+
+      await expect(promise).resolves.toEqual({ id: '3', name: 'Toto' })
+    })
+
+    test('can receive multiple subscription updates', async () => {
+      const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
+        const id = opts.input;
+        const names = ['Toto', 'Tutu', 'Titi']
+        for (let i = 0; i < names.length; i++) {
+          yield await new Promise(resolve => setTimeout(() => resolve({id, name: names[i]!}), i * 50));
+        }
+      })
+
+      server.use(subscription)
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+
+      const promise = new Promise<User[]>((resolve) => {
+        const results: User[] = []
+        trpc.getUserUpdates.subscribe('4', {
+          onData: (data) => {
+            results.push(data)
+            if (results.length === 3) {
+              resolve(results)
+            }
+          },
+        })
+      })
+
+      await expect(promise).resolves.toEqual([
+        { id: '4', name: 'Toto' },
+        { id: '4', name: 'Tutu' },
+        { id: '4', name: 'Titi' },
+      ])
+    })
+
+    test('can trigger subscription data', async () => {
+      const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
+        yield await new Promise(resolve => setTimeout(() => resolve({id: opts.input, name: 'Didier'}), 1000));
+      })
+
+      server.use(subscription)
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+
+      const startedPromise = new Promise<{ data: Promise<User> }>((resolveStarted) => {
+        const dataPromise = new Promise<User>((resolveData) => {
+          trpc.getUserUpdates.subscribe('5', {
+            onData: resolveData,
+            onStarted: () => resolveStarted({ data: dataPromise }),
+          })
+        })
+      })
+
+      const { data: dataPromise } = await startedPromise
+
+      await expect(dataPromise).resolves.toEqual({ id: '5', name: 'Didier' })
+    })
+  })
+
+  describe('nested router', () => {
+    const mswTrpc = createTRPCMsw<NestedAppRouter>({ links: mswLinks })
+
+    afterEach(() => server.resetHandlers())
+
+    test('handles queries properly', async () => {
+      server.use(mswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' })))
+
+      const trpc = createTRPCClient<NestedAppRouter>({ links: createLinks() })
+      const user = await trpc.deeply.nested.userById.query('1')
+
+      expect(user).toEqual({ id: '1', name: 'Malo' })
+    })
+
+    test('handles mutations properly', async () => {
+      server.use(mswTrpc.deeply.nested.createUser.mutation(({ input }) => ({ id: '2', name: input })))
+
+      const trpc = createTRPCClient<NestedAppRouter>({ links: createLinks() })
+      const user = await trpc.deeply.nested.createUser.mutate('Robert')
+
+      expect(user).toEqual({ id: '2', name: 'Robert' })
+    })
+
+    test('handles subscriptions properly', async () => {
+      const subscription = mswTrpc.deeply.nested.getUserUpdates.subscription(async function* (opts) {
+        const id = opts.input;
+        yield await new Promise(resolve => setTimeout(() => resolve({id, name: 'Tutu'}), 1000));
+      })
+
+      server.use(subscription)
+
+      const trpc = createTRPCClient<NestedAppRouter>({ links: createLinks() })
+
+      const promise = new Promise<User>((resolve) => {
+        trpc.deeply.nested.getUserUpdates.subscribe('21', {
+          onData: resolve,
+        })
+      })
+
+      await expect(promise).resolves.toEqual({ id: '21', name: 'Tutu' })
+    })
+  })
+})

--- a/packages/test-node/src/websocket-split/links.ts
+++ b/packages/test-node/src/websocket-split/links.ts
@@ -1,0 +1,29 @@
+import { createWSClient, httpLink, splitLink, wsLink } from '@trpc/client'
+
+import { LazyWebSocket } from '../lazy-websocket.js'
+
+export const createLinks = () => [
+  splitLink({
+    condition: (op) => op.type === 'subscription',
+    true: wsLink({
+      client: createWSClient({
+        url: 'ws://localhost:3001',
+        WebSocket: LazyWebSocket as any,
+        // During tests, we don't want to retry the connection as the connection to the websocket server
+        // starts before the proper mock server is set up, so tRPC will fall into an infinite retry loop
+        // (for some reason, the exponential backoff doesn't work as expected in this case)
+        retryDelayMs() {
+          return 1000000000
+        },
+      }),
+    }),
+    false: httpLink({
+      url: 'http://localhost:3000/trpc',
+      headers() {
+        return {
+          'content-type': 'application/json',
+        }
+      },
+    }),
+  }),
+]

--- a/packages/test-node/src/websocket/index.test.ts
+++ b/packages/test-node/src/websocket/index.test.ts
@@ -37,10 +37,12 @@ describe('with ws link', () => {
     })
 
     test('handles mutations properly', async () => {
-      server.use(mswTrpc.createUser.mutation(({ input }) => {
-        console.log('Creating user:', input)
-        return { id: '2', name: input }
-      }))
+      server.use(
+        mswTrpc.createUser.mutation(({ input }) => {
+          console.log('Creating user:', input)
+          return { id: '2', name: input }
+        })
+      )
 
       const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
       const user = await trpc.createUser.mutate('Robert')
@@ -50,8 +52,8 @@ describe('with ws link', () => {
 
     test('handles subscriptions properly', async () => {
       const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
-        const id = opts.input;
-        yield await new Promise(resolve => setTimeout(() => resolve({id, name: 'Toto'}), 1000));
+        const id = opts.input
+        yield await new Promise((resolve) => setTimeout(() => resolve({ id, name: 'Toto' }), 1000))
       })
 
       server.use(subscription)
@@ -69,10 +71,10 @@ describe('with ws link', () => {
 
     test('can receive multiple subscription updates', async () => {
       const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
-        const id = opts.input;
+        const id = opts.input
         const names = ['Toto', 'Tutu', 'Titi']
         for (let i = 0; i < names.length; i++) {
-          yield await new Promise(resolve => setTimeout(() => resolve({id, name: names[i]!}), i * 50));
+          yield await new Promise((resolve) => setTimeout(() => resolve({ id, name: names[i]! }), i * 50))
         }
       })
 
@@ -125,8 +127,8 @@ describe('with ws link', () => {
 
     test('handles subscriptions properly', async () => {
       const subscription = mswTrpc.deeply.nested.getUserUpdates.subscription(async function* (opts) {
-        const id = opts.input;
-        yield await new Promise(resolve => setTimeout(() => resolve({id, name: 'Tutu'}), 1000));
+        const id = opts.input
+        yield await new Promise((resolve) => setTimeout(() => resolve({ id, name: 'Tutu' }), 1000))
       })
 
       server.use(subscription)

--- a/packages/test-node/src/websocket/index.test.ts
+++ b/packages/test-node/src/websocket/index.test.ts
@@ -1,0 +1,145 @@
+import { createTRPCClient } from '@trpc/client'
+
+import { setupServer } from 'msw/node'
+import { describe, test, beforeAll, afterAll, expect, afterEach } from 'vitest'
+
+import { createLinks } from './links.js'
+import { AppRouter, NestedAppRouter, User } from '../routers.js'
+import { createTRPCMsw } from '../../../msw-trpc/src/index.js'
+import { createWSClient, wsLink } from '../../../msw-trpc/src/links.js'
+
+const mswLinks = [
+  wsLink({
+    client: createWSClient({
+      url: 'ws://localhost:3001',
+    }),
+  }),
+]
+
+describe('with ws link', () => {
+  const server = setupServer()
+
+  beforeAll(() => server.listen())
+  afterAll(() => server.close())
+
+  describe('simple router', () => {
+    const mswTrpc = createTRPCMsw<AppRouter>({ links: mswLinks })
+
+    afterEach(() => server.resetHandlers())
+
+    test('handles queries properly', async () => {
+      server.use(mswTrpc.userById.query(() => ({ id: '1', name: 'Malo' })))
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+      const user = await trpc.userById.query('1')
+
+      expect(user).toEqual({ id: '1', name: 'Malo' })
+    })
+
+    test('handles mutations properly', async () => {
+      server.use(mswTrpc.createUser.mutation(({ input }) => {
+        console.log('Creating user:', input)
+        return { id: '2', name: input }
+      }))
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+      const user = await trpc.createUser.mutate('Robert')
+
+      expect(user).toEqual({ id: '2', name: 'Robert' })
+    })
+
+    test('handles subscriptions properly', async () => {
+      const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
+        const id = opts.input;
+        yield await new Promise(resolve => setTimeout(() => resolve({id, name: 'Toto'}), 1000));
+      })
+
+      server.use(subscription)
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+
+      const promise = new Promise<User>((resolve) => {
+        trpc.getUserUpdates.subscribe('3', {
+          onData: resolve,
+        })
+      })
+
+      await expect(promise).resolves.toEqual({ id: '3', name: 'Toto' })
+    })
+
+    test('can receive multiple subscription updates', async () => {
+      const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
+        const id = opts.input;
+        const names = ['Toto', 'Tutu', 'Titi']
+        for (let i = 0; i < names.length; i++) {
+          yield await new Promise(resolve => setTimeout(() => resolve({id, name: names[i]!}), i * 50));
+        }
+      })
+
+      server.use(subscription)
+
+      const trpc = createTRPCClient<AppRouter>({ links: createLinks() })
+
+      const promise = new Promise<User[]>((resolve) => {
+        const results: User[] = []
+        trpc.getUserUpdates.subscribe('4', {
+          onData: (data) => {
+            results.push(data)
+            if (results.length === 3) {
+              resolve(results)
+            }
+          },
+        })
+      })
+
+      await expect(promise).resolves.toEqual([
+        { id: '4', name: 'Toto' },
+        { id: '4', name: 'Tutu' },
+        { id: '4', name: 'Titi' },
+      ])
+    })
+  })
+
+  describe('nested router', () => {
+    const mswTrpc = createTRPCMsw<NestedAppRouter>({ links: mswLinks })
+
+    afterEach(() => server.resetHandlers())
+
+    test('handles queries properly', async () => {
+      server.use(mswTrpc.deeply.nested.userById.query(() => ({ id: '1', name: 'Malo' })))
+
+      const trpc = createTRPCClient<NestedAppRouter>({ links: createLinks() })
+      const user = await trpc.deeply.nested.userById.query('1')
+
+      expect(user).toEqual({ id: '1', name: 'Malo' })
+    })
+
+    test('handles mutations properly', async () => {
+      server.use(mswTrpc.deeply.nested.createUser.mutation(({ input }) => ({ id: '2', name: input })))
+
+      const trpc = createTRPCClient<NestedAppRouter>({ links: createLinks() })
+      const user = await trpc.deeply.nested.createUser.mutate('Robert')
+
+      expect(user).toEqual({ id: '2', name: 'Robert' })
+    })
+
+    test('handles subscriptions properly', async () => {
+      const subscription = mswTrpc.deeply.nested.getUserUpdates.subscription(async function* (opts) {
+        const id = opts.input;
+        yield await new Promise(resolve => setTimeout(() => resolve({id, name: 'Tutu'}), 1000));
+      })
+
+      server.use(subscription)
+
+      const trpc = createTRPCClient<NestedAppRouter>({ links: createLinks() })
+
+      const promise = new Promise<User>((resolve) => {
+        trpc.deeply.nested.getUserUpdates.subscribe('21', {
+          onData: resolve,
+        })
+      })
+
+      await expect(promise).resolves.toEqual({ id: '21', name: 'Tutu' })
+    })
+  })
+})

--- a/packages/test-node/src/websocket/links.ts
+++ b/packages/test-node/src/websocket/links.ts
@@ -1,0 +1,18 @@
+import { createWSClient, wsLink } from '@trpc/client'
+
+import { LazyWebSocket } from '../lazy-websocket.js'
+
+export const createLinks = () => [
+  wsLink({
+    client: createWSClient({
+      url: 'ws://localhost:3001',
+      WebSocket: LazyWebSocket as any,
+      // During tests, we don't want to retry the connection as the connection to the websocket server
+      // starts before the proper mock server is set up, so tRPC will fall into an infinite retry loop
+      // (for some reason, the exponential backoff doesn't work as expected in this case)
+      retryDelayMs() {
+        return 1000000000
+      },
+    }),
+  }),
+]

--- a/packages/test-react/src/basic.test.tsx
+++ b/packages/test-react/src/basic.test.tsx
@@ -1,12 +1,13 @@
 import { describe, test, expect, beforeAll, afterAll } from 'vitest'
-import { createTRPCMsw, httpLink } from '../../msw-trpc/src'
+import { createTRPCMsw, createWSClient, httpLink, splitLink, wsLink } from '../../msw-trpc/src'
 import { setupServer } from 'msw/node'
 import { render, screen, waitFor } from '@testing-library/react'
 import type { AppRouter } from './routers/basic.js'
 
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
-import { createTRPCClient, httpLink as TRPCClientHttpLink } from '@trpc/client'
-import { createTRPCOptionsProxy } from '@trpc/tanstack-react-query'
+import { createTRPCClient, httpLink as TRPCClientHttpLink, wsLink as TRPCClientWSLink, createWSClient as TRPCCreateWSClient, TRPCLink, splitLink as TRPCClientSplitLink} from '@trpc/client'
+import { createTRPCOptionsProxy, useSubscription } from '@trpc/tanstack-react-query'
+import { useState } from 'react'
 
 describe('basic', () => {
   const server = setupServer()
@@ -69,6 +70,225 @@ describe('basic', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Tutu')).toBeInTheDocument()
+    })
+  })
+
+  test('ws link', async () => {
+    const queryClient = new QueryClient()
+
+    const links = [
+      TRPCClientWSLink({
+        client: TRPCCreateWSClient({
+          url: 'ws://localhost:3001/trpc',
+        }),
+      }), // bypassing type check
+    ]
+
+    const trpcClient = createTRPCClient<AppRouter>({ links })
+
+    const trpc = createTRPCOptionsProxy<AppRouter>({
+      client: trpcClient,
+      queryClient,
+    })
+
+    const App = () => {
+      const { data } = useQuery(trpc.userById.queryOptions('1'))
+
+      if (data) {
+        return <div>{data.name}</div>
+      }
+
+      return <div>Hello</div>
+    }
+
+    const mswTrpc = createTRPCMsw<AppRouter>({
+      links: [
+        wsLink({
+          client: createWSClient({
+            url: 'ws://localhost:3001/trpc',
+          }),
+        }),
+      ],
+    })
+
+    server.use(mswTrpc.userById.query(({ input }) => ({ id: input, name: 'Malo' })))
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Malo')).toBeInTheDocument()
+    })
+  })
+
+  test('subscriptions', async () => {
+    const queryClient = new QueryClient()
+
+    const links = [
+      TRPCClientWSLink({
+        client: TRPCCreateWSClient({
+          url: 'ws://localhost:3001/trpc',
+        }),
+      }) as unknown as TRPCLink<AppRouter>, // bypassing type check
+    ]
+
+    const trpcClient = createTRPCClient<AppRouter>({ links })
+
+    const trpc = createTRPCOptionsProxy<AppRouter>({
+      client: trpcClient,
+      queryClient,
+    })
+
+    const App = () => {
+      const [data, setData] = useState<{
+        id: string
+        name: string
+      } | null>(null)
+
+      useSubscription(
+        trpc.getUserUpdates.subscriptionOptions('1', {
+            onData: (data) => setData(data),
+          }
+        )
+      )
+
+      if (data) {
+        return <div>{data.name}</div>
+      }
+
+      return <div>Hello</div>
+    }
+
+    const mswTrpc = createTRPCMsw<AppRouter>({
+      links: [
+        wsLink({
+          client: createWSClient({
+            url: 'ws://localhost:3001/trpc',
+          }),
+        }),
+      ],
+    })
+
+    const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
+      yield await new Promise(resolve => setTimeout(() => resolve({id: opts.input, name: 'Didier'}), 500));
+    })
+
+    server.use(subscription)
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Didier')).toBeInTheDocument()
+    })
+  })
+
+  test('split link', async () => {
+    const queryClient = new QueryClient()
+
+    const links = [
+      TRPCClientSplitLink({
+        condition: (op) => {
+          return op.type === 'subscription'
+        },
+        true: TRPCClientWSLink({
+          client: TRPCCreateWSClient({
+            url: `ws://api.localhost:3001/trpc`,
+          }),
+        }),
+        false: TRPCClientHttpLink({
+          url: `http://api.localhost:3000/trpc`,
+          fetch: (url, options) => fetch(url, { ...options, credentials: 'include' }),
+        }),
+      }),
+    ]
+
+    const trpcClient = createTRPCClient<AppRouter>({ links })
+
+    const trpc = createTRPCOptionsProxy<AppRouter>({
+      client: trpcClient,
+      queryClient,
+    })
+
+    const App = () => {
+      const { data } = useQuery(trpc.userById.queryOptions('1'))
+
+      useSubscription(
+        trpc.getUserUpdates.subscriptionOptions('1', {
+            onData: (data) => setRecord(data),
+          }
+        )
+      )
+
+      const [record, setRecord] = useState<{
+        id: string
+        name: string
+      } | null>(null)
+
+      if (record) {
+        return <div>{record.name}</div>
+      }
+
+      if (data) {
+        return <div>{data.name}</div>
+      }
+
+      return <div>Hello</div>
+    }
+
+    const mswTrpc = createTRPCMsw<AppRouter>({
+      links: [
+        splitLink({
+          condition: (op) => {
+            return op.type === 'subscription'
+          },
+          true: wsLink({
+            client: createWSClient({
+              url: 'ws://api.localhost:3001/trpc',
+            }),
+          }),
+          false: httpLink({
+            url: 'http://api.localhost:3000/trpc',
+          }),
+        }),
+      ],
+    })
+
+    const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
+      yield await new Promise(resolve => setTimeout(() => resolve({id: opts.input, name: 'Didier'}), 500));
+    })
+
+    server.use(
+      mswTrpc.userById.query(({ input }) => {
+        return { id: input, name: 'Tutu' }
+      }),
+      subscription
+    )
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    )
+
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('Tutu')).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Didier')).toBeInTheDocument()
     })
   })
 })

--- a/packages/test-react/src/basic.test.tsx
+++ b/packages/test-react/src/basic.test.tsx
@@ -5,7 +5,14 @@ import { render, screen, waitFor } from '@testing-library/react'
 import type { AppRouter } from './routers/basic.js'
 
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
-import { createTRPCClient, httpLink as TRPCClientHttpLink, wsLink as TRPCClientWSLink, createWSClient as TRPCCreateWSClient, TRPCLink, splitLink as TRPCClientSplitLink} from '@trpc/client'
+import {
+  createTRPCClient,
+  httpLink as TRPCClientHttpLink,
+  wsLink as TRPCClientWSLink,
+  createWSClient as TRPCCreateWSClient,
+  TRPCLink,
+  splitLink as TRPCClientSplitLink,
+} from '@trpc/client'
 import { createTRPCOptionsProxy, useSubscription } from '@trpc/tanstack-react-query'
 import { useState } from 'react'
 
@@ -152,9 +159,8 @@ describe('basic', () => {
 
       useSubscription(
         trpc.getUserUpdates.subscriptionOptions('1', {
-            onData: (data) => setData(data),
-          }
-        )
+          onData: (data) => setData(data),
+        })
       )
 
       if (data) {
@@ -175,7 +181,7 @@ describe('basic', () => {
     })
 
     const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
-      yield await new Promise(resolve => setTimeout(() => resolve({id: opts.input, name: 'Didier'}), 500));
+      yield await new Promise((resolve) => setTimeout(() => resolve({ id: opts.input, name: 'Didier' }), 500))
     })
 
     server.use(subscription)
@@ -225,9 +231,8 @@ describe('basic', () => {
 
       useSubscription(
         trpc.getUserUpdates.subscriptionOptions('1', {
-            onData: (data) => setRecord(data),
-          }
-        )
+          onData: (data) => setRecord(data),
+        })
       )
 
       const [record, setRecord] = useState<{
@@ -265,7 +270,7 @@ describe('basic', () => {
     })
 
     const subscription = mswTrpc.getUserUpdates.subscription(async function* (opts) {
-      yield await new Promise(resolve => setTimeout(() => resolve({id: opts.input, name: 'Didier'}), 500));
+      yield await new Promise((resolve) => setTimeout(() => resolve({ id: opts.input, name: 'Didier' }), 500))
     })
 
     server.use(

--- a/packages/test-react/src/routers/basic.ts
+++ b/packages/test-react/src/routers/basic.ts
@@ -42,6 +42,15 @@ const appRouter = t.router({
         name: input,
       } as User
     }),
+  getUserUpdates: t.procedure
+    .input((val: unknown) => {
+      if (typeof val === 'string') return val
+
+      throw new Error(`Invalid input: ${typeof val}`)
+    })
+    .subscription(async function* (opts) {
+      yield { id: opts.input, name: 'Marie' } as User
+    }),
 })
 
 const nestedRouter = t.router({ deeply: { nested: appRouter } })

--- a/packages/test-react/src/routers/superjson.ts
+++ b/packages/test-react/src/routers/superjson.ts
@@ -43,6 +43,15 @@ const appRouter = t.router({
         name: input,
       } as User
     }),
+  getUserUpdates: t.procedure
+    .input((val: unknown) => {
+      if (typeof val === 'string') return val
+
+      throw new Error(`Invalid input: ${typeof val}`)
+    })
+    .subscription(async function* (opts) {
+      yield { id: opts.input, name: 'Marie' } as User
+    }),
 })
 
 export type AppRouteWithSuperJson = typeof appRouter

--- a/packages/test-react/vitest.config.ts
+++ b/packages/test-react/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     include: ['./src/**/*.test.{ts,tsx}'],
     setupFiles: './src/setup.ts',
-    environment: 'happy-dom',
+    environment: 'jsdom',
   },
 })


### PR DESCRIPTION
## 🎯 Changes

🚧 This PR is a WORK IN PROGRESS

Based off @vafanassieff's prior work w/ tRPC and observables, this PR intends to get websocket support working using async generator functions.

## ✅ Checklist

- [ ] If necessary, I have added documentation related to the changes made.
- [x] I have added or updated the tests related to the changes made.

## 🚧 TODO

- [ ] Support triggering subscription events as @vafanassieff had working previously. I think this will require setting up some kind of observable/emitter in the msw handler to consume from the async generator as well as the trigger method
- [ ] Support for legacy observables. This isn't difficult to add, just was not my top priority.
- [ ] Unit tests for tracked events.
- [ ] Websocket browser tests.